### PR TITLE
[기능구현] 전자결재 다중 조건 검색 api구현 및 사원 도메인 엔티티 getter 작성

### DIFF
--- a/DB/ApprovalDocumentDummy.sql
+++ b/DB/ApprovalDocumentDummy.sql
@@ -1,0 +1,40 @@
+-- department 테이블에 더미 데이터 삽입
+INSERT INTO department (id, name)
+VALUES (1, '인사부'),
+       (2, '재무부'),
+       (3, '마케팅부'),
+       (4, 'IT부서'),
+       (5, '영업부');
+-- job 테이블에 더미 데이터 삽입
+INSERT INTO job (id, title)
+VALUES (1, '사원'),
+       (2, '대리'),
+       (3, '과장'),
+       (4, '차장'),
+       (5, '부장');
+INSERT INTO employee (employee_id, name, english_name, hanja_name, department_id, job_id, phone, personal_id, gender,
+                      hire_date, end_date, address, nationality, birth_date, email, self_introduction,
+                      employment_status)
+VALUES (1, '홍길동', 'Hong Gildong', '洪吉童', 1, 1, '010-1234-5678', '123456-1234567', 'M', '2020-01-01', NULL, '서울시 강남구',
+        '대한민국', '1990-01-01', 'hong@example.com', '열심히 하겠습니다.', '재직'),
+       (2, '김철수', 'Kim Cheolsu', '金哲洙', 2, 2, '010-2345-6789', '234567-2345678', 'M', '2021-02-01', NULL, '서울시 서초구',
+        '대한민국', '1985-05-05', 'kim@example.com', '최선을 다하겠습니다.', '재직'),
+       (3, '이영희', 'Lee Younghee', '李英姬', 3, 3, '010-3456-7890', '345678-3456789', 'F', '2019-03-01', NULL, '서울시 종로구',
+        '대한민국', '1992-02-02', 'lee@example.com', '잘 부탁드립니다.', '재직'),
+       (4, '박영수', 'Park Youngsu', '朴英洙', 4, 4, '010-4567-8901', '456789-4567890', 'M', '2018-04-01', NULL, '서울시 용산구',
+        '대한민국', '1988-08-08', 'park@example.com', '성실히 임하겠습니다.', '재직'),
+       (5, '최지우', 'Choi Jiwoo', '崔智友', 5, 5, '010-5678-9012', '567890-5678901', 'F', '2017-05-01', NULL, '서울시 마포구',
+        '대한민국', '1995-12-12', 'choi@example.com', '감사합니다.', '재직');
+INSERT INTO approval_document_template_folder(id, `name`, ref_folder_id)
+VALUES (1, '전체', null);
+
+INSERT INTO approval_document_template(id, title, document, `status`, last_editor_id, edit_able_status, folder_id)
+VALUES (1, '템플릿 1', "ㄴㅇㄹ", 1, '3', 0, 1);
+
+INSERT INTO approval_document (document_template_id, title, draft_employee_id, approval_date, last_approval_date,
+                               department_id, document, `state`)
+VALUES (1, 'Document 1', 1, '2023-01-01', '2023-01-05', 2, 'document1.pdf', 'APPROVE'),
+       (1, 'Document 2', 2, '2023-02-01', '2023-02-10', 3, 'document2.pdf', 'APPROVE'),
+       (1, 'Document 3', 3, '2023-03-01', '2023-03-15', 1, 'document3.pdf', 'APPROVE'),
+       (1, 'Document 4', 4, '2023-04-01', '2023-04-20', 2, 'document4.pdf', 'APPROVE'),
+       (1, 'Document 5', 5, '2023-05-01', '2023-05-25', 1, 'document5.pdf', 'APPROVE');

--- a/http/document-test.http
+++ b/http/document-test.http
@@ -1,0 +1,5 @@
+### get 요청 확인
+### startDate - 기안일(min) endDate - 기안일(max) templateId - 양식 ID title -
+### 제목 draftEmployeeName - 기안자 이름 status - 결재 상태 pageSize - 한 페이지 서류 갯수
+GET http://localhost:8001/approval-document?draftEmployeeName=홍&pageSize=10
+Content-Type: application/json

--- a/src/main/java/com/errorCode/pandaOffice/PandaOfficeApplication.java
+++ b/src/main/java/com/errorCode/pandaOffice/PandaOfficeApplication.java
@@ -2,9 +2,10 @@ package com.errorCode.pandaOffice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @EnableTransactionManagement
 public class PandaOfficeApplication {
 

--- a/src/main/java/com/errorCode/pandaOffice/common/paging/Pagination.java
+++ b/src/main/java/com/errorCode/pandaOffice/common/paging/Pagination.java
@@ -2,7 +2,7 @@ package com.errorCode.pandaOffice.common.paging;
 
 import org.springframework.data.domain.Page;
 
-public class Pagenation {
+public class Pagination {
 	
 	public static PagingButtonInfo getPagingButtonInfo(Page<?> page) {
 		

--- a/src/main/java/com/errorCode/pandaOffice/e_approval/domain/entity/ApprovalDocument.java
+++ b/src/main/java/com/errorCode/pandaOffice/e_approval/domain/entity/ApprovalDocument.java
@@ -1,20 +1,23 @@
 package com.errorCode.pandaOffice.e_approval.domain.entity;
 
 import com.errorCode.pandaOffice.e_approval.domain.type.ApproveState;
+import com.errorCode.pandaOffice.employee.domain.entity.Department;
 import com.errorCode.pandaOffice.employee.domain.entity.Employee;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 @Entity
 @Table(name = "approval_document")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@ToString
 /* 전자결재 */
 public class ApprovalDocument {
     @Id
@@ -23,19 +26,26 @@ public class ApprovalDocument {
 
     /* 결재서 제목 */
     private String title;
-    /* 결재 상태 */
-    private int approvalStatus;
     @ManyToOne
+    @JoinColumn(nullable = false, name = "document_template_id")
+    private DocumentTemplate documentTemplate;
+    @ManyToOne
+//    @JoinColumn(nullable = false, name="draft_employee_id")
     @JoinColumn(nullable = false, name="draft_employee_id")
     /* 기안자 */
     private Employee draftEmployee;
     /* 기안일 */
-    private Date approvalDate;
+    private LocalDate approvalDate;
+    /* 최종 결재일 */
+    private LocalDate lastApprovalDate;
     /* 부서 ID */
-    private int departmentId;
+    @ManyToOne
+    @JoinColumn(nullable = false, name = "departmentId")
+    private Department department;
     /* 문서 파일 */
     private String document;
     /* 결재 상태 */
+    @Enumerated(EnumType.STRING)
     private ApproveState state;
     /* 문서 첨부파일 리스트 */
     @OneToMany

--- a/src/main/java/com/errorCode/pandaOffice/e_approval/domain/entity/DocumentTemplateFolder.java
+++ b/src/main/java/com/errorCode/pandaOffice/e_approval/domain/entity/DocumentTemplateFolder.java
@@ -18,5 +18,6 @@ public class DocumentTemplateFolder {
     @Column(nullable = false)
     private String name;
     /* 상위 폴더 ID */
+    @Column(nullable = true)
     private int refFolderId;
 }

--- a/src/main/java/com/errorCode/pandaOffice/e_approval/domain/repository/ApprovalDocumentRepository.java
+++ b/src/main/java/com/errorCode/pandaOffice/e_approval/domain/repository/ApprovalDocumentRepository.java
@@ -1,0 +1,9 @@
+package com.errorCode.pandaOffice.e_approval.domain.repository;
+
+import com.errorCode.pandaOffice.e_approval.domain.entity.ApprovalDocument;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface ApprovalDocumentRepository extends JpaRepository<ApprovalDocument, Long>, JpaSpecificationExecutor<ApprovalDocument> {
+
+}

--- a/src/main/java/com/errorCode/pandaOffice/e_approval/domain/repository/ApprovalDocumentSpecification.java
+++ b/src/main/java/com/errorCode/pandaOffice/e_approval/domain/repository/ApprovalDocumentSpecification.java
@@ -1,0 +1,28 @@
+package com.errorCode.pandaOffice.e_approval.domain.repository;
+
+import com.errorCode.pandaOffice.e_approval.domain.entity.ApprovalDocument;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDate;
+
+public interface ApprovalDocumentSpecification {
+    /* 검색 조건 쿼리 */
+    static Specification<ApprovalDocument> gteStartDate(LocalDate startDate) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.greaterThanOrEqualTo(root.get("approvalDate"), startDate);
+    }
+    static Specification<ApprovalDocument> lteEndDate(LocalDate endDate) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.lessThanOrEqualTo(root.get("lastApprovalDate"), endDate);
+    }
+    static Specification<ApprovalDocument> eqTemplateId(Integer templateId) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("templateId"), templateId);
+    }
+    static Specification<ApprovalDocument> containsTitle(String title) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("title"), "%" + title + "%");
+    }
+    static Specification<ApprovalDocument> containsName(String draftEmployeeName) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("draftEmployee").get("name"), "%" + draftEmployeeName + "%");
+    }
+    static Specification<ApprovalDocument> isStatus(String status) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("status"), status);
+    }
+}

--- a/src/main/java/com/errorCode/pandaOffice/e_approval/domain/repository/template.java
+++ b/src/main/java/com/errorCode/pandaOffice/e_approval/domain/repository/template.java
@@ -1,4 +1,0 @@
-package com.errorCode.pandaOffice.e_approval.domain.repository;
-
-public interface template {
-}

--- a/src/main/java/com/errorCode/pandaOffice/e_approval/domain/type/ApproveState.java
+++ b/src/main/java/com/errorCode/pandaOffice/e_approval/domain/type/ApproveState.java
@@ -1,7 +1,15 @@
 package com.errorCode.pandaOffice.e_approval.domain.type;
 
 public enum ApproveState {
-    APPROVE,
-    PROGRESS,
-    REJECTION
+    APPROVE("결재 완료"),
+    PROGRESS("진행중"),
+    REJECTION("반려");
+
+    private String state;
+
+    private ApproveState(String state) {
+        this.state = state;
+    }
+
+    public String getState() {return state;}
 }

--- a/src/main/java/com/errorCode/pandaOffice/e_approval/domain/type/ApproveType.java
+++ b/src/main/java/com/errorCode/pandaOffice/e_approval/domain/type/ApproveType.java
@@ -4,5 +4,4 @@ public enum ApproveType {
     WAIT,
     APPROVE,
     REJECTION,
-
 }

--- a/src/main/java/com/errorCode/pandaOffice/e_approval/dto/response/ApproveDocumentListResponse.java
+++ b/src/main/java/com/errorCode/pandaOffice/e_approval/dto/response/ApproveDocumentListResponse.java
@@ -1,0 +1,34 @@
+package com.errorCode.pandaOffice.e_approval.dto.response;
+
+import com.errorCode.pandaOffice.e_approval.domain.entity.ApprovalDocument;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApproveDocumentListResponse {
+    private final int id;
+    private final String title;
+    private final String templateName;
+    private final String draftEmployeeName;
+    private final LocalDate approvalDate;
+    private final LocalDate lastApprovalDate;
+    private final String departmentName;
+    private final String state;
+
+    public static ApproveDocumentListResponse from(final ApprovalDocument approvalDocument){
+        return new ApproveDocumentListResponse(
+                approvalDocument.getId(),
+                approvalDocument.getTitle(),
+                approvalDocument.getDocumentTemplate().getTitle(),
+                approvalDocument.getDraftEmployee().getName(),
+                approvalDocument.getApprovalDate(),
+                approvalDocument.getLastApprovalDate(),
+                approvalDocument.getDepartment().getName(),
+                approvalDocument.getState().getState()
+        );
+    }
+}

--- a/src/main/java/com/errorCode/pandaOffice/e_approval/dto/response/template.java
+++ b/src/main/java/com/errorCode/pandaOffice/e_approval/dto/response/template.java
@@ -1,4 +1,0 @@
-package com.errorCode.pandaOffice.e_approval.dto.response;
-
-public class template {
-}

--- a/src/main/java/com/errorCode/pandaOffice/e_approval/presectation/ApprovalDocumentController.java
+++ b/src/main/java/com/errorCode/pandaOffice/e_approval/presectation/ApprovalDocumentController.java
@@ -1,0 +1,68 @@
+package com.errorCode.pandaOffice.e_approval.presectation;
+
+import com.errorCode.pandaOffice.common.paging.Pagination;
+import com.errorCode.pandaOffice.common.paging.PagingButtonInfo;
+import com.errorCode.pandaOffice.common.paging.PagingResponse;
+import com.errorCode.pandaOffice.e_approval.domain.entity.ApprovalDocument;
+import com.errorCode.pandaOffice.e_approval.domain.repository.ApprovalDocumentSpecification;
+import com.errorCode.pandaOffice.e_approval.dto.response.ApproveDocumentListResponse;
+import com.errorCode.pandaOffice.e_approval.service.ApprovalDocumentService;
+import com.errorCode.pandaOffice.employee.domain.entity.Employee;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ApprovalDocumentController {
+    private final ApprovalDocumentService approvalDocumentService;
+
+    /* 결재 문서 가져오는 메소드 */
+    @GetMapping("/approval-document")
+    public ResponseEntity<PagingResponse> getApprovalDocuments(
+            /* 기안일 조건 (min) */
+            @RequestParam(required = false) final LocalDate startDate,
+            /* 기안일 조건 (max) */
+            @RequestParam(required = false) final LocalDate endDate,
+            /* 양식 ID */
+            @RequestParam(required = false) final Integer templateId,
+            /* 제목 */
+            @RequestParam(required = false) final String title,
+            /* 기안자 이름 */
+            @RequestParam(required = false) final String draftEmployeeName,
+            /* 결재 상태 (APPROVE, PROGRESS, REJECTION) */
+            @RequestParam(required = false) final String status,
+            /* 한 페이지 서류 량 */
+            @RequestParam(required = false) final Integer pageSize
+    ) {
+        /**
+         * 검색 조건에 맞는 서류들을 반환한다.
+         * @version : 1
+         * @author : 편승준
+         * @param : 검색 조건들. null 이 가능하다
+         * @return : 응답을 담은 Page 객체
+         * */
+        final Page<ApproveDocumentListResponse> documents = approvalDocumentService.searchDocuments(
+                startDate,
+                endDate,
+                templateId,
+                title,
+                draftEmployeeName,
+                status,
+                pageSize
+        );
+        final PagingButtonInfo pagingButtonInfo = Pagination.getPagingButtonInfo(documents);
+        final PagingResponse pagingResponse = PagingResponse.of(documents.getContent(), pagingButtonInfo);
+        System.out.println(documents);
+
+        return ResponseEntity.ok(pagingResponse);
+    }
+}

--- a/src/main/java/com/errorCode/pandaOffice/e_approval/presectation/Controller.java
+++ b/src/main/java/com/errorCode/pandaOffice/e_approval/presectation/Controller.java
@@ -1,4 +1,0 @@
-package com.errorCode.pandaOffice.e_approval.presectation;
-
-public class Controller {
-}

--- a/src/main/java/com/errorCode/pandaOffice/e_approval/service/ApprovalDocumentService.java
+++ b/src/main/java/com/errorCode/pandaOffice/e_approval/service/ApprovalDocumentService.java
@@ -1,0 +1,55 @@
+package com.errorCode.pandaOffice.e_approval.service;
+
+import com.errorCode.pandaOffice.e_approval.domain.entity.ApprovalDocument;
+import com.errorCode.pandaOffice.e_approval.domain.repository.ApprovalDocumentRepository;
+import com.errorCode.pandaOffice.e_approval.domain.repository.ApprovalDocumentSpecification;
+import com.errorCode.pandaOffice.e_approval.dto.response.ApproveDocumentListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ApprovalDocumentService {
+    private final ApprovalDocumentRepository approvalDocumentRepository;
+
+
+    public Page<ApproveDocumentListResponse> searchDocuments(LocalDate startDate, LocalDate endDate, Integer templateId, String title, String draftEmployeeName, String status, Integer pageSize) {
+
+        /* pageable 객체 */
+        Pageable pageable = PageRequest.of(0, pageSize);
+
+        /**
+         * 각각의 조건들을 확인하고 동적으로 쿼리메소드를 만든다.
+         * @version : 1
+         * @author : 편승준
+         * @see : ApprovalDocumentSpecification - 쿼리메소드 작성하는 클래스
+         * @return : find 의 명세서 spec 객체
+         * */
+        Specification<ApprovalDocument> spec = ((root, query, criteriaBuilder) -> null);
+        if (startDate != null)
+            spec = spec.and(ApprovalDocumentSpecification.gteStartDate(startDate));
+        if(endDate != null)
+            spec = spec.and(ApprovalDocumentSpecification.lteEndDate(endDate));
+        if(templateId != null)
+            spec = spec.and(ApprovalDocumentSpecification.eqTemplateId(templateId));
+        if(title != null)
+            spec = spec.and(ApprovalDocumentSpecification.containsTitle(title));
+        if(draftEmployeeName != null)
+            spec = spec.and(ApprovalDocumentSpecification.containsName(draftEmployeeName));
+        if(status != null){
+            spec = spec.and(ApprovalDocumentSpecification.isStatus(status));
+        }
+        /* Page 객체 반환 */
+        Page<ApprovalDocument> documents = approvalDocumentRepository.findAll(spec, pageable);
+        /* from 을 사용하여 response 로 변환 */
+        return documents.map(ApproveDocumentListResponse::from);
+    }
+}

--- a/src/main/java/com/errorCode/pandaOffice/e_approval/service/Service.java
+++ b/src/main/java/com/errorCode/pandaOffice/e_approval/service/Service.java
@@ -1,4 +1,0 @@
-package com.errorCode.pandaOffice.e_approval.service;
-
-public class Service {
-}

--- a/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/CareerHistory.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/CareerHistory.java
@@ -1,11 +1,13 @@
 package com.errorCode.pandaOffice.employee.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.util.Date;
 
 @Entity(name="CareerHistory")
 @Table(name="career_history")
+@Getter
 public class CareerHistory {
     @Id
     @Column(name = "id")

--- a/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/Department.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/Department.java
@@ -4,9 +4,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.Getter;
 
 @Entity
 @Table(name="department")
+@Getter
 public class Department {
     @Id
     @Column(name="id")

--- a/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/EducationHistory.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/EducationHistory.java
@@ -1,9 +1,11 @@
 package com.errorCode.pandaOffice.employee.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity(name="EducationHistory")
 @Table(name="education_history")
+@Getter
 public class EducationHistory {
     @Id
     @Column(name="id")

--- a/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/Employee.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/Employee.java
@@ -1,11 +1,13 @@
 package com.errorCode.pandaOffice.employee.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.util.Date;
 
 @Entity(name="Employee")
 @Table(name="employee")
+@Getter
 public class Employee {
 
     @Id

--- a/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/EmployeePhoto.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/EmployeePhoto.java
@@ -1,9 +1,11 @@
 package com.errorCode.pandaOffice.employee.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity(name="EmployeePhoto")
 @Table(name="employee_photo")
+@Getter
 public class EmployeePhoto {
     @Id
     @ManyToOne

--- a/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/FamilyMember.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/FamilyMember.java
@@ -1,11 +1,13 @@
 package com.errorCode.pandaOffice.employee.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.util.Date;
 
 @Entity(name="FamilyName")
 @Table(name="family_member")
+@Getter
 public class FamilyMember {
     @Id
     @Column(name="id")

--- a/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/Hobby.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/Hobby.java
@@ -1,9 +1,11 @@
 package com.errorCode.pandaOffice.employee.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity(name="Hobby")
 @Table(name="hobby")
+@Getter
 public class Hobby {
     @Id
     @Column(name="id")

--- a/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/Job.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/Job.java
@@ -4,9 +4,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.Getter;
 
 @Entity
 @Table(name="job")
+@Getter
 public class Job {
     @Id
     @Column(name="id")

--- a/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/License.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/License.java
@@ -1,11 +1,13 @@
 package com.errorCode.pandaOffice.employee.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.util.Date;
 
 @Entity(name="License")
 @Table(name="license")
+@Getter
 public class License {
 
     @Id


### PR DESCRIPTION
### 🌈이슈 번호
- ex) #33

---

### 🌿작업중인 브랜치
- ex) [feature/33-get-approval-document
---

### 🛠기능 구현 설명

--- 기안일의 최소, 최대 범위, 서류 제목, 서류 종류, 기안자, 상태 등의 다중 조건으로 검색할 수 있는 api 구현

### 📑체크리스트
- [x] 코드가 올바르게 동작하는지 확인함
- [x] 테스트를 추가하거나 수정함
- [x] 코드에 주석을 추가함
- [x] 관련 이슈 번호를 제목과 템플릿에 명시함

---

### ✏️추가사항(이미지 첨부)
-
<img width="527" alt="image" src="https://github.com/ErrorCode-510/PandaOffice_back/assets/157452370/98ea0537-4a57-4c02-9dce-75131f5e6fc6">

