### PR TITLE
[기능 구현][관리자 및 사원 기능] 내 연차 내역 페이지에 들어가는 기능 구현 완료 

### DIFF
--- a/src/main/java/com/errorCode/pandaOffice/attendance/domain/entity/AnnualLeaveCategory.java
+++ b/src/main/java/com/errorCode/pandaOffice/attendance/domain/entity/AnnualLeaveCategory.java
@@ -23,10 +23,12 @@ public class AnnualLeaveCategory {
     private String name;
 
     /* 연차 분류의 타입 */
+    /* 부여 or 소진 */
     private String type;
 
-    public AnnualLeaveCategory(int id, String name) {
+    public AnnualLeaveCategory(int id, String name, String type) {
         this.id = id;
         this.name = name;
+        this.type = type;
     }
 }

--- a/src/main/java/com/errorCode/pandaOffice/attendance/domain/entity/AnnualLeaveRecord.java
+++ b/src/main/java/com/errorCode/pandaOffice/attendance/domain/entity/AnnualLeaveRecord.java
@@ -15,7 +15,7 @@ import java.util.Date;
 @Entity
 @Table
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 /* 연차 기록 */
 public class AnnualLeaveRecord {
@@ -34,6 +34,9 @@ public class AnnualLeaveRecord {
     /* 수량 (연차를 얼마나 썼는지, 받았는지에 대한 수량임) */
     private double amount;
 
+    /* 연차에 대한 내용 */
+    private String content;
+
     @ManyToOne
     @JoinColumn(name = "employee_id")
     /* 사번 */
@@ -50,12 +53,13 @@ public class AnnualLeaveRecord {
     private ApprovalDocument approvalDocument;
 
     public AnnualLeaveRecord(int id, LocalDate date, double nowAmount, double amount,
-                             Employee employee, AnnualLeaveCategory annualLeaveCategory,
+                             String content, Employee employee, AnnualLeaveCategory annualLeaveCategory,
                              ApprovalDocument approvalDocument) {
         this.id = id;
         this.date = date;
         this.nowAmount = nowAmount;
         this.amount = amount;
+        this.content = content;
         this.employee = employee;
         this.annualLeaveCategory = annualLeaveCategory;
         this.approvalDocument = approvalDocument;

--- a/src/main/java/com/errorCode/pandaOffice/attendance/domain/repository/AnnualLeaveRecordRepository.java
+++ b/src/main/java/com/errorCode/pandaOffice/attendance/domain/repository/AnnualLeaveRecordRepository.java
@@ -5,14 +5,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface AnnualLeaveRecordRepository extends JpaRepository<AnnualLeaveRecord, Integer> {
-    List<AnnualLeaveRecord> findByEmployee_EmployeeId(int employeeId);
 
     @Query("SELECT alr " +
             "FROM AnnualLeaveRecord as alr " +
             "JOIN alr.annualLeaveCategory as ac " +
             "WHERE alr.employee.employeeId  = :employeeId")
     List<AnnualLeaveRecord> findByEmployeeIdWithCategory(@Param("employeeId") int employeeId);
+
+    List<AnnualLeaveRecord> findByEmployee_EmployeeIdAndDateBetween(int employeeId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/errorCode/pandaOffice/attendance/dto/AnnualLeaveCategory/response/AnnualLeaveCategoryResponse.java
+++ b/src/main/java/com/errorCode/pandaOffice/attendance/dto/AnnualLeaveCategory/response/AnnualLeaveCategoryResponse.java
@@ -12,25 +12,13 @@ import java.time.LocalDate;
 public class AnnualLeaveCategoryResponse {
 
     /* 연차 분류 코드 */
-    private int categoryId;
+    private int id;
 
     /* 연차 분류 이름 */
-    private String categoryName;
+    private String name;
 
-    /* 연차 기록 코드 */
-    private int recordId;
-
-    /* 연차 기록 날짜 */
-    private LocalDate recordDate;
-
-    /* 잔여 연차 */
-    private double nowAmount;
-
-    /* 연차 변동 수량 */
-    private double amount;
-
-    /* 신청 서류 코드 */
-    private int approvalDocumentId;
+    /* 연차 분류의 타입 */
+    private String type;
 
 
 

--- a/src/main/java/com/errorCode/pandaOffice/attendance/dto/AnnualLeaveRecord/response/AnnualLeaveRecordResponse.java
+++ b/src/main/java/com/errorCode/pandaOffice/attendance/dto/AnnualLeaveRecord/response/AnnualLeaveRecordResponse.java
@@ -1,55 +1,223 @@
 package com.errorCode.pandaOffice.attendance.dto.AnnualLeaveRecord.response;
 
+import com.errorCode.pandaOffice.attendance.domain.entity.AnnualLeaveRecord;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
 @ToString
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor
 public class AnnualLeaveRecordResponse {
 
-    /* 연차 기록 코드 */
-    private int id;
+    /* 2.내 연차 내역(Annual Leave Record)의 기능들 */
 
-    /* 연차 기록 변동일 */
-    private LocalDate date;
+    /* 1.클래스 안에 클래스를 명시해준다.
+    * 아래에 적힌 클래스 명들은 피그마 한 페이지 안에 들어가는 API 하나를 의미한다. */
+    private CalculateLeaveRecord calculateLeaveRecord;
 
-    /* 잔여 연차 */
-    private double nowAmount;
+    private List<UsedLeaveRecord> usedLeave;
 
-    /* 수량 (연차를 얼마나 썼는지, 받았는지에 대한 수량임) */
-    private double amount;
+    private List<CreatedRecord> createdRecord;
 
-    /* 발생 연차 */
-    private double generatedLeave;
 
-    /* 조정 연차 */
-    private double adjustedLeave;
+    /* 2.AnnualLeaveRecordResponse 타입의 of 메소드를 만들어 준다.
+     * 1.이 메소드는 service 클래스에서 쓸 것이다.
+     * 2.이 메소드는 AnnualLeaveRecord를 리스트로 형태로 받아들이고
+     * 그걸 변환 해준뒤 response 형태로 내보내는 것이다. */
+    public static AnnualLeaveRecordResponse of(List<AnnualLeaveRecord> recordList) {
 
-    /* 총 연차 */
-    private double totalLeave;
+        AnnualLeaveRecordResponse response = new AnnualLeaveRecordResponse();
 
-    /* 사용 연차 */
-    private double usedLeave;
+        response.usedLeave = recordList.stream()
+                .filter(record->record
+                        .getAnnualLeaveCategory()   //카테고리 가져오기
+                        .getType()                  // 타입명 가져오기
+                        .equals("소진"))              // 비교 결과값 (필터 완료)
+                .map(
+                        /* 한번 더 of 메소드를 작성해서 내보낼 값을 설정해준다. */
+                        recordEntity -> UsedLeaveRecord.of(recordEntity)
+                )
+                .toList();
 
-    /* 잔여 연차 */
-    private double remainingLeave;
+        response.createdRecord = recordList.stream()
+                .filter(record -> record
+                        .getAnnualLeaveCategory()
+                        .getType()
+                        .equals("부여"))
+                .map(
+                        recordEntity -> CreatedRecord.of(recordEntity)
+                )
+                .toList();
 
-    public AnnualLeaveRecordResponse(int id, LocalDate date, double nowAmount, double amount) {
-        this.id = id;
-        this.date = date;
-        this.nowAmount = nowAmount;
-        this.amount = amount;
+        response.calculateLeaveRecord = CalculateLeaveRecord.of(recordList);
+
+        return response;
     }
 
-    public AnnualLeaveRecordResponse(double generatedLeave, double adjustedLeave, double totalLeave, double usedLeave, double remainingLeave) {
-        this.generatedLeave = generatedLeave;
-        this.adjustedLeave = adjustedLeave;
-        this.totalLeave = totalLeave;
-        this.usedLeave = usedLeave;
-        this.remainingLeave = remainingLeave;
+    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 연차 계산 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
+
+
+    @Getter
+    @RequiredArgsConstructor
+    // 연차를 계산하기 위한 클래스를 따로 만들어 준다.
+    public static class CalculateLeaveRecord{
+        private double generatedLeave;
+        private double adjustedLeave;
+        private double totalLeave;
+        private double usedLeave;
+        private double remainingLeave;
+
+        public static CalculateLeaveRecord of(List<AnnualLeaveRecord> recordList) {
+
+            // 계산된 연차 내역을 위한 변수명들을 선언해준다.
+            double generatedLeave = 0.0;
+            double adjustedLeave = 0.0;
+            double totalLeave = 0.0;
+            double usedLeave = 0.0;
+
+            for (AnnualLeaveRecord record : recordList) {
+
+                String type = record.getAnnualLeaveCategory().getType();
+                String name = record.getAnnualLeaveCategory().getName();
+
+                double amount = record.getAmount();
+
+                if (name.equals("기본 발생")) {
+                    generatedLeave += amount;
+                }
+
+                switch (type) {
+                    case "부여":
+                        generatedLeave += amount;
+                        adjustedLeave += amount;
+                        totalLeave += amount;
+                        break;
+                    case "소진":
+                        adjustedLeave -= amount;
+                        usedLeave += amount;
+                        break;
+                    default:
+                        // 기타 다른 타입이 있다면 무시
+                        break;
+                }
+            }
+
+            double remainingLeave = generatedLeave + adjustedLeave - usedLeave;
+
+            CalculateLeaveRecord response = new CalculateLeaveRecord();
+            response.generatedLeave = generatedLeave;
+            response.adjustedLeave = adjustedLeave;
+            response.totalLeave = totalLeave;
+            response.usedLeave = usedLeave;
+            response.remainingLeave = remainingLeave;
+
+            return response;
+        }
+    }
+
+    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 연차 사용 내역 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
+
+    @Getter
+    @RequiredArgsConstructor
+    // 연차 사용 내역을 파악하기 위한 클래스를 따로 만들어준다.
+    public static class UsedLeaveRecord{
+
+        /* UsedLeaveRecord 에서 내보낼 필드명들을 적어준다. */
+        private String employeeName;
+        private String departmentName;
+        private String categoryName;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private double amount;
+
+
+        public static UsedLeaveRecord of(AnnualLeaveRecord recordEntity) {
+
+            UsedLeaveRecord response = new UsedLeaveRecord();
+
+            response.employeeName = recordEntity.getEmployee().getName();
+            response.departmentName = recordEntity.getEmployee().getDepartment().getName();
+            response.categoryName = recordEntity.getAnnualLeaveCategory().getName();
+            response.startDate = recordEntity.getDate();
+            response.endDate = recordEntity.getDate().plusDays(
+                    (long)Math.floor(recordEntity.getAmount())
+            );
+            response.amount = recordEntity.getAmount();
+            return response;
+        }
+    }
+
+    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 연차 생성 내역 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
+    @Getter
+    @RequiredArgsConstructor
+    public static class CreatedRecord{
+
+        private LocalDate registDate;
+        private LocalDate validityDate;
+        private String content;
+        private double amount;
+
+        public static CreatedRecord of(AnnualLeaveRecord recordEntity) {
+
+            CreatedRecord response = new CreatedRecord();
+
+            response.registDate = recordEntity.getDate();
+            response.validityDate = recordEntity.getDate().plusYears(1);
+            response.content = recordEntity.getContent();
+            response.amount = recordEntity.getAmount();
+
+            return response;
+        }
     }
 }
+
+//
+//    /* 연차 기록 코드 */
+//    private int id;
+//
+//    /* 연차 기록 변동일 */
+//    private LocalDate date;
+//
+//    /* 잔여 연차 */
+//    private double nowAmount;
+//
+//    /* 수량 (연차를 얼마나 썼는지, 받았는지에 대한 수량임) */
+//    private double amount;
+//
+//    /* 연차에 대한 내용 */
+//    private String content;
+//
+//    /* 발생 연차 */
+//    private double generatedLeave;
+//
+//    /* 조정 연차 */
+//    private double adjustedLeave;
+//
+//    /* 총 연차 */
+//    private double totalLeave;
+//
+//    /* 사용 연차 */
+//    private double usedLeave;
+//
+//    /* 잔여 연차 */
+//    private double remainingLeave;
+//
+//    public AnnualLeaveRecordResponse(int id, LocalDate date, double nowAmount, double amount) {
+//        this.id = id;
+//        this.date = date;
+//        this.nowAmount = nowAmount;
+//        this.amount = amount;
+//    }
+//
+//    public AnnualLeaveRecordResponse(double generatedLeave, double adjustedLeave, double totalLeave, double usedLeave, double remainingLeave) {
+//        this.generatedLeave = generatedLeave;
+//        this.adjustedLeave = adjustedLeave;
+//        this.totalLeave = totalLeave;
+//        this.usedLeave = usedLeave;
+//        this.remainingLeave = remainingLeave;
+//    }

--- a/src/main/java/com/errorCode/pandaOffice/attendance/presectation/AttendanceController.java
+++ b/src/main/java/com/errorCode/pandaOffice/attendance/presectation/AttendanceController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -41,22 +42,14 @@ public class AttendanceController {
     }
 
     @GetMapping("/annual-leave")
-    public ResponseEntity<AnnualLeaveRecordResponse> getAnnualLeaveRecord(@RequestParam int employeeId) {
+    public ResponseEntity<AnnualLeaveRecordResponse> getAnnualLeaveRecord(@RequestParam LocalDate searchStartDate,
+                                                                          @RequestParam LocalDate searchEndDate) {
 
-        /* 3. 서비스 객체의 getOvertimeRecord 메소드에 사번을 전달하여 연차 기록 가져오기 */
-        List<AnnualLeaveRecordResponse> annualLeaveRecordResponses = attendanceService.getAnnualLeaveRecord(employeeId);
-
-        return null;
-
-    }
-
-    @GetMapping("/annual-leave-category/{employeeId}")
-    public ResponseEntity<List<AnnualLeaveCategoryResponse>> getAnnualLeaveCategory(@PathVariable int employeeId) {
-
-        /* 4. 서비스 객체의 getAnnualLeaveCategory 메소드에 사번을 전달하여 연차 기록과 연차 기록 카테고리를 동시에 가져오기  */
-        List<AnnualLeaveCategoryResponse> categoryResponses = attendanceService.getAnnualLeaveCategory(employeeId);
+        /* 4. 서비스 객체의 getOvertimeRecord 메소드에 사번을 전달하여 연차 기록 가져오기 */
+        List<AnnualLeaveRecordResponse> annualLeaveRecordResponses = attendanceService.getAnnualLeaveRecord(searchStartDate, searchEndDate);
 
         return null;
+
     }
 
     /* 5. 해당 월, 주의 누적 근무 시간 불러오기 */
@@ -74,6 +67,17 @@ public class AttendanceController {
     public ResponseEntity<OverTimeRecordResponse> calculateOverTime(@RequestParam int employeeId) {
 
         List<OverTimeRecordResponse> overTime = attendanceService.calculateOverTime(employeeId);
+
+        return null;
+
+    }
+
+    /* 7. 해당 년도의 연차 내역 불러오기  */
+    @GetMapping("/3")
+    public ResponseEntity<AnnualLeaveRecordResponse> countAnnualLeave(@RequestParam LocalDate startDate,
+                                                                      @RequestParam LocalDate endDate) {
+
+        List<AnnualLeaveRecordResponse> everyAnnualLeave = attendanceService.getAnnualLeaveRecord(startDate, endDate);
 
         return null;
 


### PR DESCRIPTION
### 🌈이슈 번호
- ex) #84 

---

### 🌿작업중인 브랜치
- ex) feature/Create-AnnualLeaveRecord

---

### 🛠기능 구현 설명
1. 현재 날짜의 연차 내역을 나타내준다.
2. 연차의 사용 내역을 나타내준다.
3. 연차의 발생 내역을 나타내준다.
---

### 📑체크리스트
- [ ] 발생 연차, 조정 연차, 총 연차, 사용 연차의 내역을 계산하여 전달
- [ ] 필터를 사용하여 소진 내역만 전달
- [ ] 필터를 사용하여 부여 내역만 전달

---

### ✏️추가사항(이미지 첨부)
![image](https://github.com/ErrorCode-510/PandaOffice_back/assets/121045581/09ddf07a-140a-4efa-a448-1555361a3402)

