### PR TITLE
[기능 구현] 연차 캘린더에서 보여주는 내용들을 전달하도록 구현 

### DIFF
--- a/src/main/java/com/errorCode/pandaOffice/attendance/domain/repository/AnnualLeaveRecordRepository.java
+++ b/src/main/java/com/errorCode/pandaOffice/attendance/domain/repository/AnnualLeaveRecordRepository.java
@@ -17,4 +17,6 @@ public interface AnnualLeaveRecordRepository extends JpaRepository<AnnualLeaveRe
     List<AnnualLeaveRecord> findByEmployeeIdWithCategory(@Param("employeeId") int employeeId);
 
     List<AnnualLeaveRecord> findByEmployee_EmployeeIdAndDateBetween(int employeeId, LocalDate startDate, LocalDate endDate);
+
+    List<AnnualLeaveRecord> findByDateBetween(LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/errorCode/pandaOffice/attendance/service/AttendanceService.java
+++ b/src/main/java/com/errorCode/pandaOffice/attendance/service/AttendanceService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.WeekFields;
 import java.util.*;
@@ -319,7 +320,20 @@ public class AttendanceService {
      * 즉 프론트에서 날짜가 바뀐다 -> 그 날짜를 rest에서 입력받는다 -> 입력받은 날짜에 맞춰서 값을 보내준다.
      * 연차의 값 중에서 소진한 연차의 값만 보내주면 된다. */
 
+    public List<AnnualLeaveRecordResponse> getAnnualCalendar(LocalDate searchDate) {
 
+        // 검색할 달의 첫 날과 마지막 날을 계산합니다.
+        YearMonth yearMonth = YearMonth.from(searchDate);
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        // 모든 사원의 연차 기록을 검색합니다.
+        List<AnnualLeaveRecord> recordList = annualLeaveRecordRepository.findByDateBetween(startDate, endDate);
+
+        AnnualLeaveRecordResponse response = AnnualLeaveRecordResponse.of(recordList);
+
+        return List.of(response);
+    }
 
     /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 4.내 근태 신청 현황(Attendance Input Status) ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
 


### PR DESCRIPTION
### 🌈이슈 번호
- ex) #103 

---

### 🌿작업중인 브랜치
- ex) feature/103-Create-AnnualRecord-Calendar

---

### 🛠기능 구현 설명
1. 캘린더에서 그래프를 누르면 나오는 전 사원의 연차 목록에 필요한 내용들 전달하기
---

### 📑체크리스트
- [ ] 년도와 달을 기준으로 화살표를 움직일 때마다 모든 사원의 연차 기록들을 표로 나타냄

---

### ✏️추가사항(이미지 첨부)
![image](https://github.com/ErrorCode-510/PandaOffice_back/assets/121045581/255cece1-b7d0-42f3-a5ee-c9dca5d83ec9)


