### PR TITLE
[기능구현] 공지사항 삭제 구현

### DIFF
--- a/http/notice-test.http
+++ b/http/notice-test.http
@@ -1,38 +1,42 @@
-### 공지사항 전체조회
+### GET 요청 확인
 GET http://localhost:8001/notice/notices
 
 ### POST 요청 확인
 POST http://localhost:8001/notice/regist
-Access-Token: Bearer eyJkYXRlIjoxNzE5MzE0NjIwOTEyLCJ0eXBlIjoiand0IiwiYWxnIjoiSFM1MTIifQ.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImVtcGxveWVlSWQiOiIyMDE1MTUwMDMiLCJleHAiOjM2MDAwMTcxOTMxNDYyMH0.QRSX_H_fomVwienR-61PVNEq4tKomG13gzwdJTwBqVftG1X1Clq6s6E0VUxnOAcTQS7PH6HNfIsllCVtEhHr8w
+Access-Token: Bearer eyJkYXRlIjoxNzE5Mzk2NzEzMjE3LCJ0eXBlIjoiand0IiwiYWxnIjoiSFM1MTIifQ.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImVtcGxveWVlSWQiOiIyMDE1MTUwMDMiLCJleHAiOjM2MDAwMTcxOTM5NjcxM30.8bEejRLGbNxot9t8TUbEqcB6VjOrblwZobnA4je-WKcdgVrhdQJRGxHf8AibJG3WmHTOPtFl-Ijb_iwFR-9fwA
 Content-Type:application/json
 
 {
   "title": "전체회식안내",
-  "content": "장소 : 하남돼지집 본점\n시간 : 금일 오후7시",
+  "content": "장소 : 하남돼지집 본점\n시간 : 금일 오후5시",
   "category": "전체공지",
   "subCategory": null,
   "postedDate": "2024-06-26",
   "viewCount": 0,
   "status": "Y",
   "employeeId": {
-    "employeeId": 201511001
+    "employeeId": 201511004
   }
 }
 
-### put 요청 확인
-PUT http://localhost:8001/notice/notices/2
+### PUT 요청 확인
+PUT http://localhost:8001/notice/notices/7
 Access-Token: Bearer eyJkYXRlIjoxNzE5MzY2MTQ0ODcwLCJ0eXBlIjoiand0IiwiYWxnIjoiSFM1MTIifQ.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImVtcGxveWVlSWQiOiIyMDE1MTUwMDMiLCJleHAiOjM2MDAwMTcxOTM2NjE0NH0.78Zi-K-Pn8vUQksH4xXiEL9Xn6O_5MhLpcm_FH7XmHJK4WxsJy45I1LAJjv0mF-H_dcFxZ4oXf--S3WBK6SQ0A
 Content-Type:application/json
 
 {
-  "title": "전체회식안내",
+  "title": "그룹회식안내",
   "content": "장소 : 하남돼지집 본점\n시간 : 금일 오후7시",
   "category": "전체공지",
   "subCategory": null,
-  "postedDate": "2024-06-26",
+  "postedDate": "2021-06-26",
   "viewCount": 0,
   "status": "Y",
   "employeeId": {
     "employeeId": 201511001
   }
 }
+
+### DELETE 요청 확인
+DELETE http://localhost:8001/notice/notices/7
+

--- a/src/main/java/com/errorCode/pandaOffice/notice/domain/entity/Notice.java
+++ b/src/main/java/com/errorCode/pandaOffice/notice/domain/entity/Notice.java
@@ -1,14 +1,10 @@
 package com.errorCode.pandaOffice.notice.domain.entity;
-
 import com.errorCode.pandaOffice.employee.domain.entity.Employee;
-import com.errorCode.pandaOffice.notice.dto.request.NoticeRequestDTO;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 // 공지사항(게시글) 엔티티 클래스
 @Entity
@@ -36,6 +32,7 @@ public class Notice {
     @Column(name = "sub_category")
     private String subCategory;  // 소분류 (그룹 : 부서별 / 경조사 : 결혼, 부고, 돌찬치)
 
+    @CreatedDate
     @Column(name = "posted_date", nullable = false)
     private LocalDate postedDate;  // 작성일
 

--- a/src/main/java/com/errorCode/pandaOffice/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/com/errorCode/pandaOffice/notice/domain/repository/NoticeRepository.java
@@ -28,10 +28,12 @@ public interface NoticeRepository extends JpaRepository<Notice, Integer> {
     // 분류와 소분류별 공지사항 조회 (페이징 및 정렬) (최신순으로 조회)
     @EntityGraph(attributePaths = {"employee", "employee.job"})
     Page<Notice> findByCategoryAndSubCategory(String category, String subCategory, Pageable pageable);
+    Page<Notice> findByStatus(char status, Pageable pageable);
 
     // 조회수 증가
     @Transactional
     @Modifying
     @Query("UPDATE Notice n SET n.viewCount = n.viewCount + 1 WHERE n.noticeId = :noticeId")
     void incrementViewCount(@Param("noticeId") int noticeId);
+
 }

--- a/src/main/java/com/errorCode/pandaOffice/notice/dto/request/NoticeRequestDTO.java
+++ b/src/main/java/com/errorCode/pandaOffice/notice/dto/request/NoticeRequestDTO.java
@@ -20,5 +20,5 @@ public class NoticeRequestDTO {
     private Employee employeeId;  // 사원 코드
     private LocalDate postedDate;  // 작성일
     private int viewCount;  // 조회수
-    private char status;  // 상태
+    private char status;  // 공개여부(Y/N)
 }

--- a/src/main/java/com/errorCode/pandaOffice/notice/presectation/NoticeController.java
+++ b/src/main/java/com/errorCode/pandaOffice/notice/presectation/NoticeController.java
@@ -1,5 +1,4 @@
 package com.errorCode.pandaOffice.notice.presectation;
-
 import com.errorCode.pandaOffice.common.exception.NotFoundException;
 import com.errorCode.pandaOffice.common.paging.Pagination;
 import com.errorCode.pandaOffice.common.paging.PagingButtonInfo;
@@ -13,10 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.net.URI;
-import java.util.List;
+
 
 // 공지사항 컨트롤러 클래스
 @RestController
@@ -55,12 +52,11 @@ public class NoticeController {
     // 특정 공지사항 조회
     @GetMapping("/notices/{noticeId}")
     public ResponseEntity<NoticeResponseDTO> getNoticeById(@PathVariable int noticeId) {
-        final NoticeResponseDTO noticeResponse = noticeService.getNoticeById(noticeId);
-
-        if (noticeResponse != null) {
+        try {
+            final NoticeResponseDTO noticeResponse = noticeService.getNoticeById(noticeId);
             return ResponseEntity.ok(noticeResponse);
-        } else {
-            return ResponseEntity.notFound().build();
+        } catch (SecurityException e) {
+            return ResponseEntity.notFound().build();  // 공지사항을 찾을 수 없음
         }
     }
 
@@ -75,12 +71,7 @@ public class NoticeController {
     public ResponseEntity<Void> createNotice(
             @RequestBody @Valid final NoticeRequestDTO noticeRequestDTO
     ) {
-        if (noticeRequestDTO.getEmployeeId() == null) {
-            return ResponseEntity.badRequest().build();
-        }
-
         final Integer noticeId = noticeService.createNotice(noticeRequestDTO);
-
         return ResponseEntity.created(URI.create("/notice/regist/" + noticeId)).build();
     }
 
@@ -93,7 +84,6 @@ public class NoticeController {
         try {
             noticeService.modifyNotice(noticeId, noticeRequestDTO);
             return ResponseEntity.noContent().build();  // 수정 성공 시 204 No Content 응답
-
         } catch (NotFoundException e) {
             return ResponseEntity.notFound().build();  // 공지사항을 찾을 수 없을 때 404 Not Found 응답
         }
@@ -102,8 +92,11 @@ public class NoticeController {
     // 공지사항 삭제
     @DeleteMapping("/notices/{noticeId}")
     public ResponseEntity<Void> deleteNotice(@PathVariable int noticeId) {
-        noticeService.deleteNotice(noticeId);
-
-        return ResponseEntity.noContent().build();
+        try {
+            noticeService.deleteNotice(noticeId);
+            return ResponseEntity.noContent().build();  // 삭제 성공 시 204 No Content 응답
+        } catch (NotFoundException e) {
+            return ResponseEntity.notFound().build();  // 공지사항을 찾을 수 없을 때 404 Not Found 응답
+        }
     }
 }


### PR DESCRIPTION
### 🌈이슈 번호
- #92 

---

### 🌿작업중인 브랜치
- feature/92-delete-notice

---

### 🛠기능 구현 설명
- NoticeService 클래스에 공지사항을 삭제하는 deleteNotice 메소드를 추가했습니다. 이 메소드는 공지사항이 존재하지 않을 경우 NoSuchElementException을 던짐
- NoticeController 클래스에 공지사항 삭제 요청을 처리하는 deleteNotice 엔드포인트를 추가했습니다. 이 엔드포인트는 삭제 성공 시 204 No Content 응답을 반환하고, 공지사항을 찾을 수 없을 때는 404 Not Found 응답을 반환

---

### 📑체크리스트
- [x] 코드가 올바르게 동작하는지 확인함
- [x] 테스트를 추가하거나 수정함
- [x] 코드에 주석을 추가함
- [x] 관련 이슈 번호를 제목과 템플릿에 명시함

---

### ✏️추가사항(이미지 첨부)
-
