### PR TITLE
[기능 구현] 연차 조정 페이지에 필요한 기능들 구현

### DIFF
--- a/src/main/java/com/errorCode/pandaOffice/attendance/domain/repository/AnnualLeaveRecordRepository.java
+++ b/src/main/java/com/errorCode/pandaOffice/attendance/domain/repository/AnnualLeaveRecordRepository.java
@@ -19,4 +19,6 @@ public interface AnnualLeaveRecordRepository extends JpaRepository<AnnualLeaveRe
     List<AnnualLeaveRecord> findByEmployee_EmployeeIdAndDateBetween(int employeeId, LocalDate startDate, LocalDate endDate);
 
     List<AnnualLeaveRecord> findByDateBetween(LocalDate startDate, LocalDate endDate);
+
+    List<AnnualLeaveRecord> findByEmployee_HireDateBetween(LocalDate startOfJoinYear, LocalDate endOfJoinYear);
 }

--- a/src/main/java/com/errorCode/pandaOffice/attendance/dto/AnnualLeaveRecord/response/AnnualLeaveRecordResponse.java
+++ b/src/main/java/com/errorCode/pandaOffice/attendance/dto/AnnualLeaveRecord/response/AnnualLeaveRecordResponse.java
@@ -4,8 +4,10 @@ import com.errorCode.pandaOffice.attendance.domain.entity.AnnualLeaveRecord;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Getter
@@ -19,13 +21,20 @@ public class AnnualLeaveRecordResponse {
 
     /* 1.클래스 안에 클래스를 명시해준다.
     * 아래에 적힌 클래스 명들은 피그마 한 페이지 안에 들어가는 API 하나를 의미한다. */
+
+    /* 1. 내 연차 내역 페이지에 쓸 클래스 */
     private CalculateLeaveRecord calculateLeaveRecord;
 
+    /*2. */
     private List<UsedLeaveRecord> usedLeave;
 
     private List<CreatedRecord> createdRecord;
 
     private List<AnnualLeaveRecordCalendar> annualLeaveRecordCalendars;
+
+    private List<AllLeaveRecord> allLeaveRecords;
+
+    private List<GrantAndUsedLeave> grantAndUsedLeaves;
 
 
     /* 2.AnnualLeaveRecordResponse 타입의 of 메소드를 만들어 준다.
@@ -70,14 +79,39 @@ public class AnnualLeaveRecordResponse {
                 )
                 .toList();
 
+        // 연차 기록을 사원 이름으로 그룹화한 후 AllLeaveRecord로 변환하여 설정합니다.
+        response.allLeaveRecords = recordList.stream()
+                // 1. recordList를 사원 이름으로 그룹화합니다.
+                .collect(Collectors.groupingBy(record -> record.getEmployee().getName()))
+
+                // 2. 그룹화된 값을 가져옵니다 (Map<String, List<AnnualLeaveRecord>>의 values를 스트림으로 변환).
+                .values().stream()
+
+                // 3. 각 그룹 (List<AnnualLeaveRecord>)을 AllLeaveRecord로 변환합니다.
+                .map(AllLeaveRecord::of)
+
+                // 4. 변환된 AllLeaveRecord 객체들을 List로 수집합니다.
+                .collect(Collectors.toList());
+
+        response.grantAndUsedLeaves = recordList.stream()
+                // 1. recordList를 사원 이름으로 그룹화합니다.
+                .collect(Collectors.groupingBy(record -> record.getEmployee().getName()))
+
+                // 2. 그룹화된 값을 가져옵니다 (Map<String, List<AnnualLeaveRecord>>의 values를 스트림으로 변환).
+                .values().stream()
+
+                // 3. 각 그룹 (List<AnnualLeaveRecord>)을 GrantAndUsedLeave로 변환합니다.
+                .map(GrantAndUsedLeave::of)
+
+                // 4. 변환된 GrantAndUsedLeave 객체들을 List로 수집합니다.
+                .collect(Collectors.toList());
+
         return response;
     }
 
-    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 1. 내 연차 내역 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
+    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 1. 내 연차 내역 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
 
-    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 1-1.연차 계산 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
-
-
+    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 1-1.연차 계산 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
     @Getter
     @RequiredArgsConstructor
     // 연차를 계산하기 위한 클래스를 따로 만들어 준다.
@@ -138,7 +172,7 @@ public class AnnualLeaveRecordResponse {
         }
     }
 
-    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 1-2.연차 사용 내역 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
+    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 1-2.연차 사용 내역 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
 
     @Getter
     @RequiredArgsConstructor
@@ -174,7 +208,7 @@ public class AnnualLeaveRecordResponse {
         }
     }
 
-    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 1-3.연차 생성 내역 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
+    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 1-3.연차 생성 내역 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
     @Getter
     @RequiredArgsConstructor
     public static class CreatedRecord{
@@ -200,7 +234,7 @@ public class AnnualLeaveRecordResponse {
         }
     }
 
-    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 2.연차 캘린더 - 연차 기록 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
+    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 2.연차 캘린더 - 연차 기록 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
 
     @Getter
     @RequiredArgsConstructor
@@ -222,6 +256,7 @@ public class AnnualLeaveRecordResponse {
             AnnualLeaveRecordCalendar response = new AnnualLeaveRecordCalendar();
 
             response.employeeName = recordEntity.getEmployee().getName();
+            response.employeeJob = recordEntity.getEmployee().getJob().getTitle();
             response.startDate = recordEntity.getDate();
             response.endDate = recordEntity.getDate().plusDays((long) Math.floor(recordEntity.getAmount()));
 
@@ -229,28 +264,207 @@ public class AnnualLeaveRecordResponse {
         }
     }
 
-    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 3.내 근태 신청 현황 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
+    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 3.내 근태 신청 현황 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
 
+    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 4. 연차 조정 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
+    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 4-1. 사원들의 연차 정보 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
 
+    @Getter
+    @RequiredArgsConstructor
+    public static class AllLeaveRecord {
 
+        private String departmentName;
+        private String jobName;
+        private String employeeName;
+        private LocalDate hireDate;
+        private int yearsOfService;
 
+        private double totalGrantedLeave;
+        private double totalUsedLeave;
+        private double remainingLeave;
 
+        private double defaultLeave;
+        private double underOneYearLeave;
+        private double rewardLeave;
+        private double replaceLeave;
 
+        private double defaultUse;
+        private double underOneYearUse;
+        private double rewardUse;
+        private double replaceUse;
 
+        public static AllLeaveRecord of(List<AnnualLeaveRecord> recordList) {
+            AllLeaveRecord response = new AllLeaveRecord();
 
+            if (!recordList.isEmpty()) {
+                AnnualLeaveRecord firstRecord = recordList.get(0);
+                LocalDate currentDate = LocalDate.now();
 
+                response.departmentName = firstRecord.getEmployee().getDepartment().getName();
+                response.jobName = firstRecord.getEmployee().getJob().getTitle();
+                response.employeeName = firstRecord.getEmployee().getName();
+                response.hireDate = firstRecord.getEmployee().getHireDate();
+                response.yearsOfService = (int) ChronoUnit.YEARS.between(response.hireDate, currentDate);
 
+                double defaultLeave = 0.0;
+                double underOneYearLeave = 0.0;
+                double rewardLeave = 0.0;
+                double replaceLeave = 0.0;
+                double defaultUse = 0.0;
+                double underOneYearUse = 0.0;
+                double rewardUse = 0.0;
+                double replaceUse = 0.0;
 
+                for (AnnualLeaveRecord record : recordList) {
+                    switch (record.getAnnualLeaveCategory().getName()) {
+                        case "기본발생":
+                            defaultLeave += record.getAmount();
+                            break;
+                        case "1년미만":
+                            underOneYearLeave += record.getAmount();
+                            break;
+                        case "보상":
+                            rewardLeave += record.getAmount();
+                            break;
+                        case "대체":
+                            replaceLeave += record.getAmount();
+                            break;
+                        case "기본사용":
+                            defaultUse += record.getAmount();
+                            break;
+                        case "1년미만 사용":
+                            underOneYearUse += record.getAmount();
+                            break;
+                        case "보상 사용":
+                            rewardUse += record.getAmount();
+                            break;
+                        case "대체 사용":
+                            replaceUse += record.getAmount();
+                            break;
+                    }
+                }
 
+                double totalLeave = defaultLeave + underOneYearLeave + rewardLeave + replaceLeave;
+                double totalUse = defaultUse + underOneYearUse + rewardUse + replaceUse;
+                double remainingLeave = totalLeave - totalUse;
 
+                response.defaultLeave = defaultLeave;
+                response.underOneYearLeave = underOneYearLeave;
+                response.rewardLeave = rewardLeave;
+                response.replaceLeave = replaceLeave;
+                response.defaultUse = defaultUse;
+                response.underOneYearUse = underOneYearUse;
+                response.rewardUse = rewardUse;
+                response.replaceUse = replaceUse;
+                response.totalGrantedLeave = totalLeave;
+                response.totalUsedLeave = totalUse;
+                response.remainingLeave = remainingLeave;
+            }
 
+            return response;
+        }
+    }
 
+    /* ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 4-2. 클릭한 사원의 부여, 소진 연차 ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ */
 
+    @Getter
+    @RequiredArgsConstructor
+    public static class GrantAndUsedLeave {
 
+        private double defaultLeave;
+        private double underOneYearLeave;
+        private double rewardLeave;
+        private double replaceLeave;
 
+        private double defaultUse;
+        private double underOneYearUse;
+        private double rewardUse;
+        private double replaceUse;
 
+        private LocalDate date;
 
+        private LocalDate startDate;
 
+        private LocalDate endDate;
+
+        public static GrantAndUsedLeave of(List<AnnualLeaveRecord> recordList) {
+
+            GrantAndUsedLeave response = new GrantAndUsedLeave();
+
+            double defaultLeave = 0.0;
+            double underOneYearLeave = 0.0;
+            double rewardLeave = 0.0;
+            double replaceLeave = 0.0;
+
+            double defaultUse = 0.0;
+            double underOneYearUse = 0.0;
+            double rewardUse = 0.0;
+            double replaceUse = 0.0;
+
+            for (AnnualLeaveRecord record : recordList) {
+                if (record.getAnnualLeaveCategory().getType().equals("부여")) {
+                    switch (record.getAnnualLeaveCategory().getName()) {
+                        case "기본발생":
+                            defaultLeave += record.getAmount();
+                            response.date = record.getDate();
+                            break;
+                        case "1년미만":
+                            underOneYearLeave += record.getAmount();
+                            response.date = record.getDate();
+                            break;
+                        case "보상":
+                            rewardLeave += record.getAmount();
+                            response.date = record.getDate();
+                            break;
+                        case "대체":
+                            replaceLeave += record.getAmount();
+                            response.date = record.getDate();
+                            break;
+                    }
+                } else if (record.getAnnualLeaveCategory().getType().equals("소진")) {
+                    switch (record.getAnnualLeaveCategory().getName()) {
+                        case "기본사용":
+                            defaultUse += record.getAmount();
+                            response.date = record.getDate();
+                            response.startDate = record.getDate();
+                            response.endDate = record.getDate().plusDays(
+                                    (long)Math.floor(record.getAmount()));
+                            break;
+                        case "1년미만":
+                            underOneYearUse += record.getAmount();
+                            response.startDate = record.getDate();
+                            response.endDate = record.getDate().plusDays(
+                                    (long)Math.floor(record.getAmount()));
+                            break;
+                        case "보상":
+                            rewardUse += record.getAmount();
+                            response.startDate = record.getDate();
+                            response.endDate = record.getDate().plusDays(
+                                    (long)Math.floor(record.getAmount()));
+                            break;
+                        case "대체":
+                            replaceUse += record.getAmount();
+                            response.startDate = record.getDate();
+                            response.endDate = record.getDate().plusDays(
+                                    (long)Math.floor(record.getAmount()));
+                            break;
+                    }
+                }
+            }
+
+            response.defaultLeave = defaultLeave;
+            response.underOneYearLeave = underOneYearLeave;
+            response.rewardLeave = rewardLeave;
+            response.replaceLeave = replaceLeave;
+
+            response.defaultUse = defaultUse;
+            response.underOneYearUse = underOneYearUse;
+            response.rewardUse = rewardUse;
+            response.replaceUse = replaceUse;
+
+            return response;
+        }
+    }
 
 }
 

--- a/src/main/java/com/errorCode/pandaOffice/attendance/presectation/AttendanceController.java
+++ b/src/main/java/com/errorCode/pandaOffice/attendance/presectation/AttendanceController.java
@@ -21,26 +21,6 @@ public class AttendanceController {
 
     private final AttendanceService attendanceService;
 
-    /* 1. 요청 받기 */
-    @GetMapping("/attendance-record")
-    public ResponseEntity<AttendanceRecordResponse> getAttendanceRecord(@RequestParam int employeeId){
-
-        /* 2. 서비스 객체의 getAttendanceRecord 메소드에 사번 전달하여 근태 기록 가져오기 */
-        List<AttendanceRecordResponse> attendanceRecordResponse = attendanceService.getAttendanceRecord(employeeId);
-
-        return null;
-    }
-
-    @GetMapping("/overtime")
-    public ResponseEntity<OverTimeRecordResponse> getOvertimeRecord(@RequestParam int employeeId) {
-
-        /* 3. 서비스 객체의 getOvertimeRecord 메소드에 사번을 전달하여 연장근무 기록 가져오기 */
-        List<OverTimeRecordResponse> overTimeRecordResponses = attendanceService.getOvertimeRecord(employeeId);
-
-        return null;
-
-    }
-
     @GetMapping("/annual-leave")
     public ResponseEntity<AnnualLeaveRecordResponse> getAnnualLeaveRecord(@RequestParam LocalDate searchStartDate,
                                                                           @RequestParam LocalDate searchEndDate) {


### PR DESCRIPTION
### 🌈이슈 번호
- ex) #106 

---

### 🌿작업중인 브랜치
- ex) feature/106-AnnualLeaveRecord-Adjustment

---

### 🛠기능 구현 설명
- 입사년도를 검색하여 전체적인 연차를 확인할 수 있음
- 표를 클릭했을때 나오는 부여 연차와 소진 연차의 내역을 나오게 할 수 있음
- 조정 연차 부분을 통해서 사원의 연차를 부여 할 수 있음
---

### 📑체크리스트
- [ ] 입사년도를 매개변수 삼아서 검색되도록 작성
- [ ] 검색된 사원들 목록과 동시에 사원들의 "현년도" 연차 내역을 확인 할 수 있음
- [ ] 클릭하면 그 사원의 연차 부여, 소진 내역을 확인 할 수 있음
- [ ] 연차 조정 부분에서 플러스 버튼과 마이너스 버튼을 눌러 잔여 연차에 값을 더해서 연차를 부여할 수 있음

---

### ✏️추가사항(이미지 첨부)
![image](https://github.com/ErrorCode-510/PandaOffice_back/assets/121045581/a98c279f-e62b-49ec-ae2c-3c0a2b9fd0da)

