### PR TITLE
[기능구현] 조직도 수정 구현

### DIFF
--- a/http/organization-test.http
+++ b/http/organization-test.http
@@ -18,3 +18,14 @@ GET http://localhost:8001/org/job
 
 ### 특정 사원의 취미 조회
 GET http://localhost:8001/org/employee/201511001/hobby
+
+### 특정 사원 정보 수정
+PUT http://localhost:8001/org/employee/201511001
+Access-Token: Bearer eyJkYXRlIjoxNzE5NTYyODA0NzM5LCJ0eXBlIjoiand0IiwiYWxnIjoiSFM1MTIifQ.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImVtcGxveWVlSWQiOiIyMDE1MTEwMDEiLCJleHAiOjM2MDAwMTcxOTU2MjgwNH0.6QpKnS4WCbSA-sVq2U4TM5O0875xQgEaEkBgsy-mpShItBjhzuHgDZj6u6py_AzPC_Y_Vx83_iAQjTvt1S_ORA
+Content-Type: application/json
+
+{
+  "email": "123@gmail.com",
+  "selfIntroduction": "안녕하세요",
+  "hobby": ["운동"]
+}

--- a/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/Employee.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/Employee.java
@@ -1,7 +1,10 @@
 package com.errorCode.pandaOffice.employee.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
+
 import java.time.LocalDate;
 
 @Getter
@@ -53,9 +56,10 @@ public class Employee {
     private String employmentStatus;
     /* 사원의 연봉 정보 추가 */
     @Column(name="annual_salary")
-    private int annualAalary;
+    private int annualSalary;
     private String refreshToken;
     protected Employee(){}
+
 
     public Employee(int employeeId, String name, String englishName, String hanjaName, Department department, Job job, String phone, String personalId, String gender, LocalDate hireDate, LocalDate endDate, String address, String nationality, LocalDate birthDate, String email, String selfIntroduction, String employmentStatus, String password) {
         this.employeeId = employeeId;
@@ -80,5 +84,13 @@ public class Employee {
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
+    public void updateSelfIntroduction(String selfIntroduction) {
+        this.selfIntroduction = selfIntroduction;
     }
 }

--- a/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/Hobby.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/domain/entity/Hobby.java
@@ -2,6 +2,7 @@ package com.errorCode.pandaOffice.employee.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Entity(name="Hobby")
@@ -11,12 +12,13 @@ public class Hobby {
     @Id
     @Column(name="id")
     private int id;
+
     @ManyToOne
     @JoinColumn(name="employee_id")
     private Employee employee;
     @Column(name="hobby")
     private String hobby;
-    protected Hobby() {
+    public Hobby() {
 
     }
 
@@ -25,8 +27,4 @@ public class Hobby {
         this.employee = employee;
         this.hobby = hobby;
     }
-
-
-
-
 }

--- a/src/main/java/com/errorCode/pandaOffice/employee/domain/repository/EmployeeRepository.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/domain/repository/EmployeeRepository.java
@@ -2,7 +2,10 @@ package com.errorCode.pandaOffice.employee.domain.repository;
 
 import com.errorCode.pandaOffice.employee.domain.entity.Employee;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
@@ -18,4 +21,14 @@ public interface EmployeeRepository extends JpaRepository<Employee, Integer> {
     List<Employee> findByJobId(int jobId);
 
     List<Employee> findByNameContaining(String name);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Employee e SET e.email = :email WHERE e.employeeId = :employeeId")
+    void updateEmail(int employeeId, String email);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Employee e SET e.selfIntroduction = :selfIntroduction WHERE e.employeeId = :employeeId")
+    void updateSelfIntroduction(int employeeId, String selfIntroduction);
 }

--- a/src/main/java/com/errorCode/pandaOffice/employee/domain/repository/HobbyRepository.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/domain/repository/HobbyRepository.java
@@ -2,8 +2,11 @@ package com.errorCode.pandaOffice.employee.domain.repository;
 
 import com.errorCode.pandaOffice.employee.domain.entity.Hobby;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -12,5 +15,11 @@ public interface HobbyRepository extends JpaRepository<Hobby, Integer> {
 
     // 특정 사원의 ID를 기반으로 취미를 조회
     @Query("SELECT h FROM Hobby h WHERE h.employee.employeeId = :employeeId")
-    List<Hobby> findByEmployee(int employeeId);
+    List<Hobby> findByEmployee(@Param("employeeId") int employeeId);
+
+    // 특정 사원의 ID를 기반으로 취미를 삭제
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Hobby h WHERE h.employee.employeeId = :employeeId")
+    void deleteByEmployee(int employeeId);
 }

--- a/src/main/java/com/errorCode/pandaOffice/employee/dto/request/OrganizationRequestDTO.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/dto/request/OrganizationRequestDTO.java
@@ -3,9 +3,13 @@ package com.errorCode.pandaOffice.employee.dto.request;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 public class OrganizationRequestDTO {
 
     private String name;
+    private String selfIntroduction;
+    private List<String> hobby;
 }

--- a/src/main/java/com/errorCode/pandaOffice/employee/dto/response/OrganizationResponseDTO.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/dto/response/OrganizationResponseDTO.java
@@ -3,6 +3,7 @@ package com.errorCode.pandaOffice.employee.dto.response;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Setter
@@ -25,7 +26,7 @@ public class OrganizationResponseDTO {
 
     private String email;  // 이메일
 
-    private String hobby;  // 취미
+    private List<String> hobby;  // 취미
 
     private String selfIntroduction;  // 자기소개
 

--- a/src/main/java/com/errorCode/pandaOffice/employee/presentation/OrganizationController.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/presentation/OrganizationController.java
@@ -66,4 +66,11 @@ public class OrganizationController {
         List<Hobby> hobbies = organizationService.getHobbyByEmployee(employeeId);
         return ResponseEntity.ok(hobbies);
     }
+
+    // 사원 정보 수정
+    @PutMapping("/employee/{employeeId}")
+    public ResponseEntity<Void> updateEmployee(@PathVariable int employeeId, @RequestBody OrganizationResponseDTO requestDTO) {
+        organizationService.updateEmployee(employeeId, requestDTO);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/errorCode/pandaOffice/employee/service/OrganizationService.java
+++ b/src/main/java/com/errorCode/pandaOffice/employee/service/OrganizationService.java
@@ -63,6 +63,25 @@ public class OrganizationService {
         return hobbyRepository.findByEmployee(employeeId);
     }
 
+    // 특정 사원의 이메일, 취미, 자기소개를 업데이트
+    public void updateEmployee(int employeeId, OrganizationResponseDTO requestDTO) {
+
+        // 필요한 필드만 업데이트
+        if (requestDTO.getEmail() != null) {
+            employeeRepository.updateEmail(employeeId, requestDTO.getEmail());
+        }
+        if (requestDTO.getSelfIntroduction() != null) {
+            employeeRepository.updateSelfIntroduction(employeeId, requestDTO.getSelfIntroduction());
+        }
+        if (requestDTO.getHobby() != null && !requestDTO.getHobby().isEmpty()) {
+            // 기존 취미 삭제
+            hobbyRepository.deleteByEmployee(employeeId);
+            // 새로운 취미 추가
+            Employee employee = employeeRepository.findById(employeeId).orElseThrow();
+            requestDTO.getHobby().forEach(h -> hobbyRepository.save(new Hobby(0, employee, h)));
+        }
+    }
+
     // Employee 엔티티를 OrganizationResponseDTO 로 변환
     private OrganizationResponseDTO convertToDTO(Employee employee) {
         OrganizationResponseDTO dto = new OrganizationResponseDTO();
@@ -82,7 +101,7 @@ public class OrganizationService {
 
         // Hobby 조회
         List<Hobby> hobbies = hobbyRepository.findByEmployee(employee.getEmployeeId());
-        dto.setHobby(hobbies.isEmpty() ? "N/A" : hobbies.stream().map(Hobby::getHobby).collect(Collectors.joining(", ")));
+        dto.setHobby(hobbies.isEmpty() ? List.of("N/A") : hobbies.stream().map(Hobby::getHobby).collect(Collectors.toList()));
 
         return dto;
     }


### PR DESCRIPTION
### 🌈이슈 번호
- #111 

---

### 🌿작업중인 브랜치
- feature/111-put-org-chart

---

### 🛠기능 구현 설명
- 직원 정보를 수정하기 위한 PUT 요청을 처리하는 새로운 엔드포인트를 추가
엔터티의 setter 메서드를 사용하지 않고 이메일, 자기소개, 취미를 업데이트하는 서비스 메서드를 구현
이메일과 자기소개를 직접 업데이트하기 위해 EmployeeRepository를 사용
HobbyRepository에서 기존 취미를 삭제하고 새로운 취미를 추가하여 취미를 업데이트 하는 기능을 구현
---

### 📑체크리스트
- [x] 코드가 올바르게 동작하는지 확인함
- [x] 테스트를 추가하거나 수정함
- [x] 코드에 주석을 추가함
- [x] 관련 이슈 번호를 제목과 템플릿에 명시함

---

### ✏️추가사항(이미지 첨부)
-![조직도 수정](https://github.com/ErrorCode-510/PandaOffice_back/assets/157452568/def774be-6e71-4422-a9da-979b7811d4fe)

